### PR TITLE
cache likes_count and comments_count in redis

### DIFF
--- a/comments/api/tests.py
+++ b/comments/api/tests.py
@@ -139,4 +139,41 @@ class CommentApiTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['results'][0]['tweet']['comments_count'], 2)
 
+    def test_comments_count_with_cache(self):
+        tweet_url = '/api/tweets/{}/'.format(self.tweet.id)
+        response = self.linghu_client.get(tweet_url)
+        self.assertEqual(self.tweet.comments_count, 0)
+        self.assertEqual(response.data['comments_count'], 0)
+
+        data = {'tweet_id': self.tweet.id, 'content': 'a comment'}
+        for i in range(2):
+            _, client = self.create_user_and_client('user{}'.format(i))
+            client.post(COMMENT_URL, data)
+            response = client.get(tweet_url)
+            self.assertEqual(response.data['comments_count'], i + 1)
+            self.tweet.refresh_from_db()
+            self.assertEqual(self.tweet.comments_count, i + 1)
+
+        comment_data = self.dongxie_client.post(COMMENT_URL, data).data
+        response = self.dongxie_client.get(tweet_url)
+        self.assertEqual(response.data['comments_count'], 3)
+        self.tweet.refresh_from_db()
+        self.assertEqual(self.tweet.comments_count, 3)
+
+        # update comment should not update comments_count
+        comment_url = '{}{}/'.format(COMMENT_URL, comment_data['id'])
+        response = self.dongxie_client.put(comment_url, {'content': 'updated'})
+        self.assertEqual(response.status_code, 200)
+        response = self.dongxie_client.get(tweet_url)
+        self.assertEqual(response.data['comments_count'], 3)
+        self.tweet.refresh_from_db()
+        self.assertEqual(self.tweet.comments_count, 3)
+
+        # delete a comment will update comments_count
+        response = self.dongxie_client.delete(comment_url)
+        self.assertEqual(response.status_code, 200)
+        response = self.linghu_client.get(tweet_url)
+        self.assertEqual(response.data['comments_count'], 2)
+        self.tweet.refresh_from_db()
+        self.assertEqual(self.tweet.comments_count, 2)
 

--- a/comments/listeners.py
+++ b/comments/listeners.py
@@ -1,4 +1,4 @@
-from utils.listeners import invalidate_object_cache
+from utils.redis_helper import RedisHelper
 
 def incr_comments_count(sender, instance, created, **kwargs):
     from tweets.models import Tweet
@@ -8,11 +8,11 @@ def incr_comments_count(sender, instance, created, **kwargs):
         return
 
     Tweet.objects.filter(id=instance.tweet_id).update(comments_count=F('comments_count') + 1)
-    invalidate_object_cache(sender=Tweet, instance=instance.tweet)
+    RedisHelper.incr_count(instance.tweet, 'comments_count')
 
 def decr_comments_count(sender, instance, **kwargs):
     from tweets.models import Tweet
     from django.db.models import F
 
     Tweet.objects.filter(id=instance.tweet_id).update(comments_count=F('comments_count') -1)
-    invalidate_object_cache(sender=Tweet, instance=instance.tweet)
+    RedisHelper.decr_count(instance.tweet, 'comments_count')

--- a/likes/api/tests.py
+++ b/likes/api/tests.py
@@ -196,4 +196,43 @@ class LikeApiTests(TestCase):
         response = self.dongxie_client.get(tweet_url)
         self.assertEqual(response.data['likes_count'], 0)
 
+    def test_likes_count_with_cache(self):
+        tweet = self.create_tweet(self.linghu)
+        self.create_newsfeed(self.linghu, tweet)
+        self.create_newsfeed(self.dongxie, tweet)
 
+        data = {'content_type': 'tweet', 'object_id': tweet.id}
+        tweet_url = TWEET_DETAIL_API.format(tweet.id)
+        for i in range(3):
+            _, client = self.create_user_and_client('someone{}'.format(i))
+            client.post(LIKE_BASE_URL, data)
+
+            # check tweet api
+            response = client.get(tweet_url)
+            self.assertEqual(response.data['likes_count'], i+1)
+            tweet.refresh_from_db()
+            self.assertEqual(tweet.likes_count, i+1)
+
+        self.dongxie_client.post(LIKE_BASE_URL, data)
+        response = self.dongxie_client.get(tweet_url)
+        self.assertEqual(response.data['likes_count'], 4)
+        tweet.refresh_from_db()
+        self.assertEqual(tweet.likes_count, 4)
+
+        # check newsfeed api
+        newsfeed_url = '/api/newsfeeds/'
+        response = self.linghu_client.get(newsfeed_url)
+        self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 4)
+        response = self.dongxie_client.get(newsfeed_url)
+        self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 4)
+
+        # dongxie canceled likes
+        self.dongxie_client.post(LIKE_BASE_URL + 'cancel/', data)
+        tweet.refresh_from_db()
+        self.assertEqual(tweet.likes_count, 3)
+        response = self.dongxie_client.get(tweet_url)
+        self.assertEqual(response.data['likes_count'], 3)
+        response = self.linghu_client.get(newsfeed_url)
+        self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 3)
+        response = self.linghu_client.get(newsfeed_url)
+        self.assertEqual(response.data['results'][0]['tweet']['likes_count'], 3)

--- a/likes/listeners.py
+++ b/likes/listeners.py
@@ -1,3 +1,5 @@
+from utils.redis_helper import RedisHelper
+
 def incr_likes_count(sender, instance, created, **kwargs):
     from tweets.models import Tweet
     from django.db.models import F
@@ -9,8 +11,11 @@ def incr_likes_count(sender, instance, created, **kwargs):
     if model_class != Tweet:
         return
 
+    # can't use tweet.likes_count += 1; tweet.save() way.
+    # as this is not atom action, must use update db operation.
+    Tweet.objects.filter(id=instance.object_id).update(likes_count=F('likes_count') + 1)
     tweet = instance.content_object
-    Tweet.objects.filter(id=tweet.id).update(likes_count=F('likes_count') + 1)
+    RedisHelper.incr_count(tweet, 'likes_count')
 
 def decr_likes_count(sender, instance, **kwargs):
     from tweets.models import Tweet
@@ -20,5 +25,6 @@ def decr_likes_count(sender, instance, **kwargs):
     if model_class != Tweet:
         return
 
+    Tweet.objects.filter(id=instance.object_id).update(likes_count = F('likes_count') - 1)
     tweet = instance.content_object
-    Tweet.objects.filter(id=tweet.id).update(likes_count = F('likes_count') - 1)
+    RedisHelper.decr_count(tweet, 'likes_count')

--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -5,6 +5,7 @@ from accounts.api.serializers import UserSerializerForTweet
 from comments.api.serializers import CommentSerializer
 from likes.services import LikeService
 from likes.api.serializers import LikeSerializer
+from utils.redis_helper import RedisHelper
 
 class TweetSerializer(serializers.ModelSerializer):
     user = UserSerializerForTweet(source='cached_user')
@@ -28,10 +29,10 @@ class TweetSerializer(serializers.ModelSerializer):
         return LikeService.has_liked(self.context['request'].user, obj)
 
     def get_likes_count(self, obj):
-        return obj.like_set.count()
+        return RedisHelper.get_count(obj, 'likes_count')
 
     def get_comments_count(self, obj):
-        return obj.comment_set.count()
+        return RedisHelper.get_count(obj, 'comments_count')
 
 class TweetSerializerForCreate(serializers.ModelSerializer):
 

--- a/tweets/api/views.py
+++ b/tweets/api/views.py
@@ -25,6 +25,8 @@ class TweetViewSet(viewsets.GenericViewSet):
     @required_params(params=['user_id'])
     def list(self, request, *args, **kwargs):
         user_id = request.query_params['user_id']
+        tweets = Tweet.objects.filter(user_id=user_id).prefetch_related('user')
+
         cached_tweets = TweetService.get_cached_tweets(user_id)
         page = self.paginator.paginate_cached_list(cached_tweets, request)
         if page is None:


### PR DESCRIPTION
1. add redis_helper to incr or decr likes_count and comments_count
2. add get_count in redis_helper to get tweet likes or comments count from db or cache. 
3. update likes or comments api to incr or decr likes_count or comments_count when like or comment save.
4. update tweet serializer to get likes or comments count from redis cache.   
5. add unit tests. 